### PR TITLE
Fix dependecy: ModuleNotFoundError: No module named 'backtester'

### DIFF
--- a/Pairs Trading.ipynb
+++ b/Pairs Trading.ipynb
@@ -26,6 +26,7 @@
     "!pip install tensorboardX --user\n",
     "!pip install pandas==0.24.2 --user\n",
     "!pip install bs4 --user\n",
+    "!pip install plotly --user\n",
     "!pip install -U auquan_toolbox --user"
    ]
   },

--- a/momentum_backtest_losing_money.ipynb
+++ b/momentum_backtest_losing_money.ipynb
@@ -9,6 +9,7 @@
     "%pip install pandas==0.24.1 --user\n",
     "%pip install tensorboardX --user\n",
     "%pip install bs4 --user\n",
+    "%pip install plotly --user\n",
     "%pip install -U auquan_toolbox --user"
    ]
   },

--- a/momentum_backtest_making_money.ipynb
+++ b/momentum_backtest_making_money.ipynb
@@ -9,6 +9,7 @@
     "%pip install pandas==0.24.1 --user\n",
     "%pip install tensorboardX --user\n",
     "%pip install bs4 --user\n",
+    "%pip install plotly --user\n",
     "%pip install -U auquan_toolbox --user"
    ]
   },


### PR DESCRIPTION
Fix: `ModuleNotFoundError: No module named 'backtester'` Error on cellul 8.
```
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-15-9a2abbeb289f> in <module>
----> 1 from backtester.dataSource.yahoo_data_source import YahooStockDataSource
      2 from datetime import datetime
      3 
      4 startDateStr = '2007/12/01'
      5 endDateStr = '2017/12/01'

ModuleNotFoundError: No module named 'backtester'
```
By adding the **plotly** package, needed by **[auquan_toolbox](https://pypi.org/project/auquan-toolbox/)** package.
```
!pip install plotly --user
```
Fixes the problem.